### PR TITLE
run_oscar process json definition

### DIFF
--- a/run_oscar.json
+++ b/run_oscar.json
@@ -1,0 +1,107 @@
+{
+    "id": "run_oscar",
+    "summary": "Run an external OSCAR service.",
+    "description": "Run an external docker-based OSCAR service.",
+    "categories": [
+        "oscar",
+        "service"
+    ],
+    "experimental": true,
+    "parameters": [
+        {
+            "name": "token_env_var",
+            "description": "OpenEO auth token environment variable.",
+            "schema": {
+                "title": "token-env-var",
+                "type": "string",
+                "subtype": "string",
+                "pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+            }
+        },
+        {
+            "name": "oscar_endpoint",
+            "description": "The URL of the OSCAR service.",
+            "schema": {
+                "title": "oscar-url",
+                "type": "string",
+                "format": "url",
+                "subtype": "url",
+                "pattern": "^https?://"
+            }
+        },
+        {
+            "name": "service",
+            "description": "The OSCAR service to be executed.",
+            "schema": {
+                "title": "service",
+                "type": "string",
+                "subtype": "string"
+            }
+        },
+        {
+            "name": "output",
+            "description": "The output path for the result.",
+            "schema": {
+                "title": "output",
+                "type": "string",
+                "subtype": "string"
+            }
+        },
+        {
+            "name": "input_file",
+            "description": "input file to be uploaded.",
+            "schema": {
+                "title": "input-file",
+                "type": "string",
+                "subtype": "string"
+            }
+        },
+        {
+            "name": "service_config",
+            "description": "Optional configuration for the OSCAR service.",
+            "optional": true,
+            "schema": {
+                "title": "service-config",
+                "type": "object",
+                "subtype": "json"
+            }
+        }
+    ],
+    "returns": {
+        "description": "The output file path resulting from the OSCAR service.",
+        "schema": {
+            "type": "string",
+            "subtype": "string"
+        }
+    },
+    "exceptions": {
+        "OscarNotAvailable": {
+            "description": "The OSCAR service is not available."
+        },
+        "OscarUrlError": {
+            "description": "The OSCAR URL is not valid or cannot be reached."
+        },
+        "OscarServiceNotFound": {
+            "description": "The specified OSCAR service is not found."
+        },
+        "OscarServiceCreationError": {
+            "description": "The OSCAR service creation failed."
+        },
+        "MinioConnectionError": {
+            "description": "The MinIO connection failed."
+        },
+        "MinioUploadError": {
+            "description": "The MinIO upload failed."
+        },
+        "MinioDownloadError": {
+            "description": "The MinIO download failed."
+        }
+    },
+    "links": [
+        {
+            "href": "https://docs.oscar.grycap.net/",
+            "rel": "about",
+            "title": "OSCAR documentation"
+        }
+    ]
+}

--- a/run_oscar.json
+++ b/run_oscar.json
@@ -1,7 +1,7 @@
 {
     "id": "run_oscar",
     "summary": "Run an external OSCAR service.",
-    "description": "Run an external docker-based OSCAR service.",
+    "description": "Run an external docker based OSCAR service. TODO:expand",
     "categories": [
         "oscar",
         "service"
@@ -9,14 +9,67 @@
     "experimental": true,
     "parameters": [
         {
-            "name": "token_env_var",
-            "description": "OpenEO auth token environment variable.",
+            "name": "data",
+            "description": "The input data.",
             "schema": {
-                "title": "token-env-var",
+                "title": "data",
+                "type": "object",
+                "subtype": "data"
+            }
+        },
+        {
+            "name": "input_stac_url",
+            "description": "The URL of the STAC item to be processed by the OSCAR service.",
+            "schema": {
+                "title": "input-stac-url",
+                "type": "string",
+                "format": "url",
+                "subtype": "url",
+                "pattern": "^https?://"
+            },
+            "optional": false
+        },
+        {
+            "name": "service",
+            "description": "The name of the OSCAR service to run.",
+            "schema": {
+                "title": "service",
                 "type": "string",
                 "subtype": "string",
                 "pattern": "^[a-zA-Z0-9_\\-\\.]+$"
             }
+        },
+        {
+            "name": "service_config",
+            "description": "Configuration for the OSCAR service.",
+            "schema": {
+                "title": "service-config",
+                "type": "object",
+                "subtype": "json"
+            }
+        },
+        {
+            "name": "input_file",
+            "description": "Path to the input file to be processed by the OSCAR service.",
+            "schema": {
+                "title": "input-file",
+                "type": "string",
+                "subtype": "file"
+            },
+            "optional": true,
+            "default": null
+        },
+        {
+            "name": "output",
+            "description": "The name of the output data cube.",
+            "schema": {
+                "title": "output",
+                "type": "string",
+                "subtype": "string",
+                "pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+            },
+            "optional": false,
+            "default": "output"
         },
         {
             "name": "oscar_endpoint",
@@ -30,48 +83,53 @@
             }
         },
         {
-            "name": "service",
-            "description": "The OSCAR service to be executed.",
+            "name": "oscar_script",
+            "description": "Shell script that is run inside the OSCAR container.",
             "schema": {
-                "title": "service",
+                "title": "oscar-script",
                 "type": "string",
-                "subtype": "string"
+                "subtype": "url",
+                "format": "url",
+                "pattern": "^https?://"
             }
         },
         {
-            "name": "output",
-            "description": "The output path for the result.",
+            "name": "auth_token",
+            "description": "Authentication token for the OSCAR service.",
             "schema": {
-                "title": "output",
+                "title": "auth-token",
                 "type": "string",
-                "subtype": "string"
+                "subtype": "string",
+                "pattern": "^[a-zA-Z0-9_\\-\\.]+$"
             }
         },
         {
-            "name": "input_file",
-            "description": "input file to be uploaded.",
+            "name": "local_refresh_token",
+            "description": "Path to the local refresh token json file.",
             "schema": {
-                "title": "input-file",
+                "title": "local-refresh-token",
                 "type": "string",
-                "subtype": "string"
-            }
-        },
-        {
-            "name": "service_config",
-            "description": "Optional configuration for the OSCAR service if not available",
+                "subtype": "string",
+                "pattern": "^/.*"
+            },
             "optional": true,
+            "default": null
+        },
+        {
+            "name": "context",
+            "description": "Additional data to be passed to the OSCAR service.",
             "schema": {
-                "title": "service-config",
-                "type": "object",
-                "subtype": "json"
-            }
+                "description": "Any data type."
+            },
+            "optional": true,
+            "default": null
         }
     ],
     "returns": {
-        "description": "The output file path resulting from the OSCAR service.",
+        "description": "A data cube with the result of the OSCAR service.",
         "schema": {
-            "type": "string",
-            "subtype": "string"
+            "type": "object",
+            "subtype": "data"
         }
     },
     "exceptions": {
@@ -80,21 +138,6 @@
         },
         "OscarUrlError": {
             "description": "The OSCAR URL is not valid or cannot be reached."
-        },
-        "OscarServiceNotFound": {
-            "description": "The specified OSCAR service is not found."
-        },
-        "OscarServiceCreationError": {
-            "description": "The OSCAR service creation failed."
-        },
-        "MinioConnectionError": {
-            "description": "The MinIO connection failed."
-        },
-        "MinioUploadError": {
-            "description": "The MinIO upload failed."
-        },
-        "MinioDownloadError": {
-            "description": "The MinIO download failed."
         }
     },
     "links": [

--- a/run_oscar.json
+++ b/run_oscar.json
@@ -58,7 +58,7 @@
         },
         {
             "name": "service_config",
-            "description": "Optional configuration for the OSCAR service.",
+            "description": "Optional configuration for the OSCAR service if not available",
             "optional": true,
             "schema": {
                 "title": "service-config",


### PR DESCRIPTION
related to: https://github.com/Open-EO/openeo-processes/issues/531

## Inputs

*token_env_var* - OpenEO authentication token to be read from an environmental variable to access OSCAR deployment

*oscar_endpoint - base URL for an OSCAR deployment

*service* - The service to be run in OSCAR (a container basically)

*output* - Output path in OSCAR

*input_file* - Bash script to be executed in the service/container

*service_config* - If a service is not available and needs to be created this defines which container to register etc.

## Output

Returns the output file path. This is temporary/undecided as ideally the OSCAR services that interact with openeo shall publish the results to S3 and STAC automatically to make them readable in OpenEO again.

CC @clausmichele